### PR TITLE
Slack prototype functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,24 @@ AWS SNS hook requires the following configuration keys:
 
 Your AWS credentials should be stored in `~/.aws/credentials`.
 
+## Hook type: slackdiff
+
+The `slackdiff` hook posts config diffs to a channel of your choice using a webhook. It only triggers for post_store events.
+
+You will need to manually install the `slack-notifier` gem on your system.
+
+Configuration example:
+
+``` yaml
+hooks:
+  slack:
+    type: slackdiff
+    events: [post_store]
+    webhook_url: SLACK_WEBHOOK_URL__GENERATE_VIA_YOUR_SLACK_ADMIN_CONSOLE
+    channel: #network-changes
+    username: oxidized
+```
+
 # Ruby API
 
 The following objects exist in Oxidized.

--- a/lib/oxidized/hook/slackdiff.rb
+++ b/lib/oxidized/hook/slackdiff.rb
@@ -1,0 +1,20 @@
+require 'slack-notifier'
+
+class SlackDiff < Oxidized::Hook
+  def validate_cfg!
+    raise KeyError, 'hook.webhook_url is required' unless cfg.has_key?('webhook_url')
+    raise KeyError, 'hook.channel is required' unless cfg.has_key?('channel')
+    raise KeyError, 'hook.username is required' unless cfg.has_key?('username')
+  end
+
+  def run_hook(ctx)
+    if ctx.node
+      if ctx.event.to_s == "post_store"
+        notifier = Slack::Notifier.new cfg.webhook_url, channel: cfg.channel, username: cfg.username
+        diff = `cd #{ctx.node.repo.to_s} && git diff --no-color #{ctx.commitref.to_s}~1..#{ctx.commitref.to_s}`
+        text = "#{ctx.node.name.to_s} #{ctx.node.group.to_s} #{ctx.node.model.class.name.to_s.downcase}\n```#{diff}```"
+        notifier.post text: text
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Uses a webhook, must be pre-created by your slack admin
- Post a message including hostname, group and model
- Diff is generated by forking - needs to be improved (use rugged or nodes.get_diff)